### PR TITLE
style: fix z-index of cta button on hero section

### DIFF
--- a/src/lib/components/sections/hero.svelte
+++ b/src/lib/components/sections/hero.svelte
@@ -13,7 +13,7 @@
 			We build digital solutions that are both beautiful, functional, efficient and user-friendly.
 			We aim to inspire through our work, leaving a lasting impression on your users.
 		</p>
-		<div class="mt-10 z-50 flex items-center gap-x-6">
+		<div class="mt-10 z-10 flex items-center gap-x-6">
 			<a href="/contact" class="btn variant-filled-primary">Get started</a>
 			<a href="/portfolio" class="text-sm font-semibold leading-6 text-white"
 				>Learn more <span aria-hidden="true">→</span></a


### PR DESCRIPTION
CTA is now in the back of drawer/left nav
<img width="496" alt="image" src="https://github.com/daedalus-developers/daedalus.codes/assets/67414853/602a4f68-a003-4441-bcec-00eee1197509">
