### PR TITLE
Set light mode text colors. Fixes #160

### DIFF
--- a/src/lib/components/forms/text-input.svelte
+++ b/src/lib/components/forms/text-input.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <label class="label">
-	{#if label}<span class="text-sm font-semibold leading-6 text-white">{label}</span><br />{/if}
+	{#if label}<span class="text-sm font-semibold leading-6 dark:text-white">{label}</span><br />{/if}
 	<input
 		class={sx('input-bordered input', errors ? 'input-error' : '')}
 		type="text"

--- a/src/routes/(default)/contact/+page.svelte
+++ b/src/routes/(default)/contact/+page.svelte
@@ -46,12 +46,12 @@
 						></div>
 					</div>
 				</div>
-				<h2 class="text-3xl font-bold tracking-tight text-white">Get in touch</h2>
-				<p class="mt-6 text-lg leading-8 text-gray-300">
+				<h2 class="text-3xl font-bold tracking-tight dark:text-white">Get in touch</h2>
+				<p class="mt-6 text-lg leading-8 dark:text-gray-300">
 					Proin volutpat consequat porttitor cras nullam gravida at. Orci molestie a eu arcu. Sed ut
 					tincidunt integer elementum id sem. Arcu sed malesuada et magna.
 				</p>
-				<dl class="mt-10 space-y-4 text-base leading-7 text-gray-300">
+				<dl class="mt-10 space-y-4 text-base leading-7 dark:text-gray-300">
 					<div class="flex gap-x-4">
 						<dt class="flex-none">
 							<span class="sr-only">Address</span>


### PR DESCRIPTION
This sets the TW CSS for the text contents of the Contact component from `text-<color>` to `dark:text-<color>`.

However, the contact form component uses the TextInput component. The current PR should fix all further issues with text from the TextInput component not reacting to dark mode setting.