### PR TITLE
fix: Missing images on mobile view #195

### DIFF
--- a/src/lib/components/sections/hero.svelte
+++ b/src/lib/components/sections/hero.svelte
@@ -11,7 +11,7 @@
 	<div
 		class="absolute bottom-32 left-0 z-0 h-52 w-60 rounded-full bg-secondary-800 blur-[150px] filter lg:h-80 lg:w-96"
 	></div>
-	<Container addClass="flex QQQ flex-col md:flex-row relative text-neutral-100 py-12">
+	<Container addClass="flex QQQ flex-col md:flex-row relative text-neutral-100 py-6">
 		<div class="lg:gap-10X flex w-full flex-col justify-center text-center md:text-left">
 			<h1 class="mb-10 text-5xl font-black lg:text-7xl">Carry the world with our craftmanship</h1>
 			<p class="mb-10">

--- a/src/lib/components/sections/hero.svelte
+++ b/src/lib/components/sections/hero.svelte
@@ -11,7 +11,7 @@
 	<div
 		class="absolute bottom-32 left-0 z-0 h-52 w-60 rounded-full bg-secondary-800 blur-[150px] filter lg:h-80 lg:w-96"
 	></div>
-	<Container addClass="flex QQQ flex-col md:flex-row relative text-neutral-100 py-20">
+	<Container addClass="flex QQQ flex-col md:flex-row relative text-neutral-100 py-12">
 		<div class="lg:gap-10X flex w-full flex-col justify-center text-center md:text-left">
 			<h1 class="mb-10 text-5xl font-black lg:text-7xl">Carry the world with our craftmanship</h1>
 			<p class="mb-10">

--- a/src/routes/(default)/DaedalusCommunity.svelte
+++ b/src/routes/(default)/DaedalusCommunity.svelte
@@ -4,7 +4,7 @@
 	import { ASSET_URL } from '@utils';
 </script>
 
-<section class="bg-surface-100-800-token py-32 dark:bg-transparent">
+<section class="bg-surface-100-900-token py-12 dark:bg-transparent">
 	<Container>
 		<div class="flex flex-wrap">
 			<div class="w-full pb-20 md:max-w-[50%]">
@@ -51,14 +51,7 @@
 					</div>
 				</div>
 			</div>
-
-			<div class="relative -z-10 mt-[-35%] w-full opacity-70 md:max-w-[50%]">
-				<img
-					src={`${ASSET_URL}saly.png`}
-					alt="thumbnail"
-					class="mx-auto ms-auto block max-w-[500px] md:hidden"
-				/>
-			</div>
+			<img src={`${ASSET_URL}saly.png`} alt="thumbnail" class="max-w-1/2 mx-auto md:hidden" />
 		</div>
 	</Container>
 </section>

--- a/src/routes/(default)/DaedalusCommunity.svelte
+++ b/src/routes/(default)/DaedalusCommunity.svelte
@@ -4,7 +4,7 @@
 	import { ASSET_URL } from '@utils';
 </script>
 
-<section class="bg-surface-100-900-token py-12 dark:bg-transparent">
+<section class="bg-surface-100-900-token py-20 dark:bg-transparent">
 	<Container>
 		<div class="flex flex-wrap">
 			<div class="w-full pb-20 md:max-w-[50%]">

--- a/src/routes/(default)/MissionVision.svelte
+++ b/src/routes/(default)/MissionVision.svelte
@@ -3,7 +3,7 @@
 	import { Container } from '@components/utilities';
 </script>
 
-<section class="bg-transparent py-32 dark:bg-surface-100-800-token">
+<section class="bg-transparent py-12 dark:bg-surface-100-800-token">
 	<Container>
 		<div class="embla" use:emblaCarouselSvelte>
 			<div class="embla__container">

--- a/src/routes/(default)/MissionVision.svelte
+++ b/src/routes/(default)/MissionVision.svelte
@@ -3,7 +3,7 @@
 	import { Container } from '@components/utilities';
 </script>
 
-<section class="bg-transparent py-12 dark:bg-surface-100-800-token">
+<section class="bg-transparent py-20 dark:bg-surface-100-800-token">
 	<Container>
 		<div class="embla" use:emblaCarouselSvelte>
 			<div class="embla__container">

--- a/src/routes/(default)/Projects.svelte
+++ b/src/routes/(default)/Projects.svelte
@@ -15,7 +15,7 @@
 	const dummyCardCount = 6;
 </script>
 
-<section class="py-32 dark:bg-surface-100-800-token">
+<section class="py-12 dark:bg-surface-100-800-token">
 	<Container>
 		<div class="mb-20 flex">
 			<h2

--- a/src/routes/(default)/Team.svelte
+++ b/src/routes/(default)/Team.svelte
@@ -5,9 +5,9 @@
 	import { page } from '$app/stores';
 </script>
 
-<section class="relative py-32">
+<section class="relative py-12">
 	<div
-		class="bg-surface-100-800-token absolute bottom-[unset] left-0 top-0 -z-10 h-[50%] w-full dark:bottom-0 dark:top-[unset]"
+		class="bg-surface-100-900-token absolute bottom-[unset] left-0 top-0 -z-10 h-[50%] w-full dark:bottom-0 dark:top-[unset]"
 	></div>
 	<Container addClass="flex flex-col gap-10">
 		<div class="flex flex-col md:flex-row">


### PR DESCRIPTION
This PR also adjusted the common padding set onto the components where it was too big `py-32` to `py-12`


There is also need to refactor the current components as they are reliant on going relative positions which is bad for the responsive design. if we are gonna limit the landing page into 3 members, 3 projects and 3 events, we should also consider removing the carousels, please respond before i close the PR. @erikachenchan 


- [x] Closes #195 
